### PR TITLE
Update instructions.md

### DIFF
--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -37,5 +37,5 @@ The discount is always passed as a number, where `42%` becomes `0.42`. The resul
 
 ```javascript
 priceWithMonthlyDiscount(89, 230, 0.42);
-// => 97972
+// => 98010
 ```


### PR DESCRIPTION
Correct miscalculated price of discounted rate for large projects



Day Rate=89×8=712
Full Months. Each month has 22 days:

Full Months- rounding up: 230/22 = 10months approximately

Remaining Days= 230 − (10 × 22) =10 days
Step 4: Monthly Discounted Rate
For each full month:

Monthly Rate (Discounted)= 712 × 22 × (1−0.42) = 9089.76
Rounding up = 9089

Full Month Cost= 10 × 9089 = 90890
Step 6: Cost for Remaining Days
The remaining 10 days are billed at the full day rate, that is 10 × 712 = 7120

Total Cost= 90890 + 7120 = 98010

Rounding to the nearest whole number, the result is 98010.